### PR TITLE
Do not precise source of deployed service

### DIFF
--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -15,6 +15,3 @@ tasks:
           specification:
             accessibility:
               from_external: true
-            source:
-              image: docker.io/alistairstead/continuous-generators
-              tag: latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 app:
   build: .
+  environment:
+    PORT: 80
   expose:
     - 80
-  ports:
-    - "80:8080"


### PR DESCRIPTION
- That removes the `tag` parameter, as it is changing when branches or changing. If you mention it, then it'll always deploy the same image, whatever the branch you try to deploy
- Remove the `image` parameter in source as it is automatically guessed